### PR TITLE
Set arch to arm64 if uname -m returns arm64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -42,7 +42,7 @@ download_release() {
 
   local arch
   [ "x86_64" = "$(uname -m)" ] && arch="amd64" || arch="386"
-  [ "aarcah64" = "$(uname -m)" ] && arch="arm64"
+  [ "aarcah64" = "$(uname -m)" ] || [ "arm64" = "$(uname -m)" ] && arch="arm64"
 
   url="$GH_REPO/releases/download/v${version}/grpc_health_probe-${platform}-${arch}"
 


### PR DESCRIPTION
In mac with M* processors `uname -m` returns `arm64` but the plugin now sets the arch to 386, and the download link results in https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.28/grpc_health_probe-darwin-386 which does not exists.

Here the fix to set arch to `arm64` when `uname -m` returns `arm64`